### PR TITLE
improve ja localization

### DIFF
--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,6 +1,6 @@
 {
   "appName": {
-    "message": "ビン電源(ノード検査マネージャー)",
+    "message": "NIM (Node Inspector Manager)",
     "description": "The title of the extension displayed in the web store."
   },
   "appShortName": {
@@ -8,47 +8,47 @@
     "description": "The short title."
   },
   "appDescription": {
-    "message": "拡張のために自動的に起動V8調査のためのNode.js デバッグ",
+    "message": "Node.jsのデバッグのため、 V8 Inspectorを自動で起動する拡張機能です。",
     "description": "A description of the extension displayed in the web store."
   },
   "pageOptionsTitle": {
-    "message": "ビン電源(ノード検査マネージャー)-オプションページ",
+    "message": "NIM (Node Inspector Manager) - Options Page",
     "description": "Title shown on options page."
   },
   "defaultTitle": {
-    "message": "ビン電源(ノード検査マネージャー)",
+    "message": "NIM (Node Inspector Manager)",
     "description": "Title shown in tooltip."
   },
   "errMsg1": {
-    "message": "エラー設定をアンインストールURL: ",
+    "message": "Error setting uninstall URL: ",
     "description": "Error message."
   },
   "errMsg2": {
-    "message": "閉じたタブのためのDevToolsセッション: ",
+    "message": "Closed tab for DevTools session: ",
     "description": "Error message."
   },
   "errMsg6": {
-    "message": "閉じたウィンドウDevToolsセッション: ",
+    "message": "Closed window for DevTools session: ",
     "description": "Error message."
   },
   "errMsg3": {
-    "message": "エラーをしようとオートあり ",
+    "message": "Error while trying to auto close ",
     "description": "Error message."
   },
   "errMsg4": {
-    "message": "接続DevToolsホストが中断されました。 チェックをホストとポートします。",
+    "message": "デベロッパーツールへの接続が中断されました。ホストとポートを確認してください。",
     "description": "Error message."
   },
   "errMsg5": {
-    "message": "DevToolsが開いています。",
+    "message": "デベロッパーツールはすでに開いています。",
     "description": "Error message."
   },
   "errMsg7": {
-    "message": "DevToolsが開いています。",
+    "message": "デベロッパーツールはすでに開いています。",
     "description": "Error message."
   },
   "errMsg8": {
-    "message": "DevToolsが開いています。",
+    "message": "デベロッパーツールはすでに開いています。",
     "description": "Storage key $key$ in namespace $namespace$ changed.  Old value was $oldvalue$, new value is $newvalue$",
     "placeholders": {
       "key": {
@@ -66,19 +66,19 @@
     }
   },
   "port": {
-    "message": "港",
+    "message": "ポート",
     "description": "Port."
   },
   "hostname": {
-    "message": "ホスト名",
+    "message": "ホスト",
     "description": "Hostname."
   },
   "manual": {
-    "message": "マニュアル",
+    "message": "Manual",
     "description": "Manual."
   },
   "auto": {
-    "message": "オート",
+    "message": "Auto",
     "description": "Auto."
   },
   "donate": {
@@ -86,63 +86,63 @@
     "description": "Donate."
   },
   "enabled": {
-    "message": "有効な",
+    "message": "Enabled",
     "description": "Enabled."
   },
   "uptime": {
-    "message": "アップタイム",
+    "message": "Uptime",
     "description": "Uptime."
   },
   "options": {
-    "message": "オプション",
+    "message": "Options",
     "description": "Options."
   },
   "general": {
-    "message": "一般",
+    "message": "General",
     "description": "General."
   },
   "on": {
-    "message": "月",
+    "message": "On",
     "description": "On."
   },
   "off": {
-    "message": "オフ",
+    "message": "Off",
     "description": "Off."
   },
   "openInspectorNewWindow": {
-    "message": "新しいウィンドウで開きます。",
+    "message": "新しいウィンドウで開く",
     "description": "Open Inspector in a new window."
   },
   "makeInspectorWindowFocused": {
-    "message": "作画面にフォーカスします。",
+    "message": "ウィンドウにフォーカスを移動する",
     "description": "Make Inspector window focused."
   },
   "makeInspectorTabActive": {
-    "message": "をタブで活躍しました。",
+    "message": "タブをアクティブにする",
     "description": "Make Inspector tab active."
   },
   "autoCloseInspector": {
-    "message": "自動的に閉じます。",
+    "message": "自動で閉じる",
     "description": "Auto close the Inspector."
   },
   "secondsBetweenInspectorChecks": {
-    "message": "チェック間隔で出ています。",
+    "message": "チェック間隔",
     "description": "Seconds between Inspector checks."
   },
   "debugging": {
-    "message": "デバッグ",
+    "message": "Debugging",
     "description": "Debugging."
   },
   "showDebugWindow": {
-    "message": "示デバッグウインドウです。",
+    "message": "デバッグウィンドウを表示",
     "description": "Show debug window."
   },
   "save": {
-    "message": "保存",
+    "message": "Save",
     "description": "Save."
   },
   "openDevtools": {
-    "message": "開DevTools",
+    "message": "Open DevTools",
     "description": "Open DevTools"
   },
   "seconds": {


### PR DESCRIPTION
 I would like to help in improving ja localization as a Japanese native speaker.

I made some minor changes in `_locales/ja/messages.json`.
some messages are English because they are more familiar to Japanese developers than translated term.

## screenshots
<img width="497" alt="mainview" src="https://cloud.githubusercontent.com/assets/19371353/21321230/5891a524-c657-11e6-85d1-d60876a61f67.png">
<img width="395" alt="option" src="https://cloud.githubusercontent.com/assets/19371353/21321231/5898572a-c657-11e6-86d9-43f46b067c87.png">
 