### PR TITLE
Allow users to pick faster polling rate

### DIFF
--- a/options.js
+++ b/options.js
@@ -46,7 +46,7 @@ ngApp
             start: [$scope.bg.settings.checkInterval],
             step: 1,
             range: {
-                'min': [3],
+                'min': [1],
                 'max': [300]
             },
             tooltips: true


### PR DESCRIPTION
3 seconds is quite slow I believe.
I tried slower than 1 second and it crashed (many tabs were opening at once), so I am not completely sure 1 second polling rate will work correctly. However for me, it does.