### PR TITLE
Use full options title on header of options page

### DIFF
--- a/options.html
+++ b/options.html
@@ -21,7 +21,7 @@
 <body id="nim" ng-controller="nimOptionsController as main">
     <div>
         <div class="row">
-            <div class="col s12 center white-text" id="options-header"><span class="i18n">options</span></div>
+            <div class="col s12 center white-text" id="options-header"><span class="i18n">pageOptionsTitle</span></div>
         </div>
         <div class="row">
             <div class="col s12">


### PR DESCRIPTION
When you right click NiM extension and click options there is a heading-less page labeled "options" that leaves no indication as to which app it is for. Using the full page title here seems apt.

Node.js V8 --inspector Manager (NiM) - Options Page
vs
Options (for what, digital ocean - the current advertiser????)


![image](https://user-images.githubusercontent.com/4075001/126701242-89d24874-cd99-4f2a-9815-4b3f066ae50a.png)


![image](https://user-images.githubusercontent.com/4075001/126701218-f9c6d57e-86df-4ae5-a6f1-4ca4696b1181.png)
